### PR TITLE
Repath stylesheets using new way of producing VS Code URLs

### DIFF
--- a/src/preview-panel-scope.ts
+++ b/src/preview-panel-scope.ts
@@ -138,11 +138,12 @@ function repathLocalFiles(html: string, templateDocument: TextDocument) {
             elm.attribs['href'].toLowerCase().endsWith('.css')
         )
         .each((i, elm) => {
-            const newHref = templateDocument.uri.with({
-                scheme: 'vscode-resource',
-                path: path.join(path.dirname(templateDocument.fileName), elm.attribs['href']),
-            }).toString();
             const cacheClear = new Date().getTime();
+
+            const newHref = elm.attribs['src'] = Uri
+                .file(path.join(path.dirname(templateDocument.fileName), elm.attribs['href']))
+                .with({ scheme: 'vscode-resource' }).toString();
+
             elm.attribs['href'] = `${newHref}?${cacheClear}`;
         });
 


### PR DESCRIPTION
@benlongmire 

I had to make a change in the repathing of images due to a change in the underlying API: https://github.com/johnknoop/vscode-handlebars-preview/commit/8dcd3b914100968da732a37bfd060e8eaad149d8

I applied the same fix to the CSS repathing, and it seems to work from the limited testing I've done, but I thought you might wanna try it out with your files as well.

If you could find the time to try it out, I'd be very thankful.