### PR TITLE
Adding support for Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Open a Handlebars file, select **Handlebars: Preview** from the command menu **o
 # Features
 
 ✅ Image support\
-✅ [Automatically scans your workspace folder(s) for partials](#partials)\
+✅ [Automatically scans your workspace folder(s) for partials and helpers](#partials)\
 ✅ [Auto-refresh](#auto-refresh)\
 ✅ [Generate context file from a template](#generate-context-file-from-template)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,28 @@ Partials are automatically discovered and given names based off of the workspace
 ```
 Then the two partials will be registered as `partials/footer` and `partials/style/dark` respectively.
 
+## Helpers
+Helpers can be defined as javascript modules and will be automatically discovered and registered. Helpers can be placed anywhere in the Workspace, as long as they use the double file extentions like: `.hbs.js` or `.handlebars.js`.
+   
+As an example, a typical helper file could look like this:
+```js
+// my_helpers.handlebars.js
+
+module.exports = {
+    toUpperCase: function (text) {
+        return text.toUpperCase();
+    },
+    toLowerCase: function (text) {
+        return text.toLowerCase();
+    }
+};
+```
+And could be used like this inside your Handlebars template to properly cast the `title` variable to upperCase:
+
+```hbs
+{{toUpperCase title}}
+```
+
 ## Auto-refresh
 Changes to Handlebars templates applied in real-time. Included partials need to be saved in order for the change to take effect.
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import generateContext from "./context-generator/context-generator";
 import { Subject, race } from "rxjs";
 import { debounceTime, filter, take, repeat } from "rxjs/operators";
 import { partialsRegistered, findAndRegisterPartials, watchForPartials } from './partials';
+import { helpersRegistered, findAndRegisterHelpers, watchForHelpers } from './helpers';
 
 const panels: PreviewPanelScope[] = [];
 export const showErrorMessage = new Subject<{ message: string; panel: PreviewPanelScope; } | null>();
@@ -70,6 +71,7 @@ export function activate(context: ExtensionContext) {
 	});
 
 	context.subscriptions.push(previewCommand, ...watchForPartials(panels), generateContextFromExplorerCommand);
+	context.subscriptions.push(previewCommand, ...watchForHelpers(panels), generateContextFromExplorerCommand);
 }
 
 async function openPreviewPanelByUri(uri: Uri) {
@@ -104,6 +106,10 @@ async function openPreviewPanelByDocument(doc: TextDocument) {
 
 	if (!partialsRegistered(workspaceRoot.uri.fsPath)) {
 		await findAndRegisterPartials(workspaceRoot);
+	}
+
+	if (!helpersRegistered(workspaceRoot.uri.fsPath)) {
+		await findAndRegisterHelpers(workspaceRoot);
 	}
 
 	try {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,46 @@
+import { promises } from 'fs';
+import { registerHelper } from 'handlebars';
+import { workspace, WorkspaceFolder, RelativePattern } from 'vscode';
+import { PreviewPanelScope } from './preview-panel-scope';
+
+const helpersRegisteredByWorkspace = {};
+
+export function helpersRegistered(workspaceRoot: string) {
+	return workspaceRoot in helpersRegisteredByWorkspace;
+}
+
+export async function findAndRegisterHelpers(workspaceFolder: WorkspaceFolder) {
+	const jsFiles = await workspace.findFiles(new RelativePattern(workspaceFolder, '**/*.{hbs,handlebars}.js'));
+
+	for (const js of jsFiles) {
+		let helper = await import(js.fsPath);
+		Object.keys(helper).forEach(key => registerHelper(key, helper[key]));
+	}
+
+	helpersRegisteredByWorkspace[workspaceFolder.uri.fsPath] = true;
+}
+
+export function* watchForHelpers(panels: PreviewPanelScope[]) {
+	const watcher = workspace.createFileSystemWatcher('**/*.{hbs,handlebars}.js');
+
+	yield watcher.onDidCreate(async (e) => {
+		let helper = await import(e.fsPath);
+		Object.keys(helper).forEach(key => registerHelper(key, helper[key]));
+
+		for (const panel of panels) {
+			await panel.update();
+		}
+	});
+
+	yield watcher.onDidChange(async (e) => {
+		// make sure to remove the previous module from the cache
+		delete require.cache[require.resolve(e.fsPath)];
+		// import the module
+		let helper = await import(e.fsPath);
+		Object.keys(helper).forEach(key => registerHelper(key, helper[key]));
+
+		for (const panel of panels) {
+			await panel.update();
+		}
+	});
+}

--- a/src/preview-panel-scope.ts
+++ b/src/preview-panel-scope.ts
@@ -117,19 +117,26 @@ function repathLocalFiles(html: string, templateDocument: TextDocument) {
 
     // Images
     $('img')
-        .filter((i, elm) => 
+        .filter((i, elm) =>
+            // satisfy typing
+            elm.type === 'tag' &&
             // Skip data-urls
             elm.attribs['src'].trimLeft().slice(0, 5).toLowerCase() !== 'data:' &&
             // Skip remote images
             !elm.attribs['src'].toLowerCase().startsWith('http')
         )
         .each((i, elm) => {
-            elm.attribs['src'] = Uri.file(path.join(path.dirname(templateDocument.fileName), elm.attribs['src'])).with({ scheme: 'vscode-resource' }).toString();
+            // satisfy typing
+            if (elm.type === 'tag') {
+                elm.attribs['src'] = Uri.file(path.join(path.dirname(templateDocument.fileName), elm.attribs['src'])).with({ scheme: 'vscode-resource' }).toString();
+            }
         });
     
     // CSS
     $('link')
         .filter((i, elm) => 
+            // satisfy typing
+            elm.type === 'tag' &&
             // Skip data-urls
             elm.attribs['href'].trimLeft().slice(0, 5).toLowerCase() !== 'data:' &&
             // Skip remote css
@@ -138,13 +145,17 @@ function repathLocalFiles(html: string, templateDocument: TextDocument) {
             elm.attribs['href'].toLowerCase().endsWith('.css')
         )
         .each((i, elm) => {
-            const cacheClear = new Date().getTime();
+            // satisfy typing
+            if (elm.type === 'tag') {
 
-            const newHref = elm.attribs['src'] = Uri
-                .file(path.join(path.dirname(templateDocument.fileName), elm.attribs['href']))
-                .with({ scheme: 'vscode-resource' }).toString();
+                const cacheClear = new Date().getTime();
 
-            elm.attribs['href'] = `${newHref}?${cacheClear}`;
+                const newHref = elm.attribs['src'] = Uri
+                    .file(path.join(path.dirname(templateDocument.fileName), elm.attribs['href']))
+                    .with({ scheme: 'vscode-resource' }).toString();
+
+                elm.attribs['href'] = `${newHref}?${cacheClear}`;
+            }
         });
 
     const repathedHtml = $.html({


### PR DESCRIPTION
This PR adds support for Helpers in the form of additional `hbs.js` or `handlebars.js` files exposing individual helper functions using `module.exports`. See the Readme changes for more details on its implementation.

@johnknoop let me know if this is what you had in mind. It works for my purpose, but maybe some more elaborate testing would be useful.

fixes #12 

